### PR TITLE
feat: add standalone build and a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use the official Node.js runtime as the base image
+FROM node:21 as build
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the entire application code to the container
+COPY . .
+
+# Build the React app for production
+RUN npm run standalone
+
+# Use Nginx as the production server
+FROM nginx:alpine
+
+# Copy the built React app to Nginx's web server directory
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Expose port 80 for the Nginx server
+EXPOSE 80
+
+# Start Nginx when the container runs
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/pages/docs/isopacks.mdx
+++ b/docs/pages/docs/isopacks.mdx
@@ -28,7 +28,7 @@ npm i @isoflow/isopacks
 
 ```jsx showLineNumbers
 import Isoflow from 'isoflow';
-import { flattenCollections } from 'isoflow/dist/utils';
+import { flattenCollections } from '@isoflow/isopacks/dist/utils';
 import isoflowIsopack from '@isoflow/isopacks/dist/isoflow';
 import awsIsopack from '@isoflow/isopacks/dist/aws';
 import gcpIsopack from '@isoflow/isopacks/dist/gcp';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:fix": "eslint --fix ./src/**/*.{ts,tsx}",
     "docs:dev": "cd ./docs && npm run dev",
     "docs:build": "cd ./docs && npm run build",
-    "docs:start": "cd ./docs && npm run start"
+    "docs:start": "cd ./docs && npm run start",
+    "standalone": "webpack --config ./webpack/standalone.config.js"
   },
   "devDependencies": {
     "@isoflow/isopacks": "^0.0.10",

--- a/webpack/standalone.config.js
+++ b/webpack/standalone.config.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  mode: 'production',
+  entry: './src/index.tsx',
+  target: 'web',
+  output: {
+    path: path.resolve(__dirname, '../dist'),
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader']
+      },
+        
+        {
+          test: /\.svg$/i,
+          type: 'asset/inline'
+        }
+    ]
+  },
+  plugins: [
+    new HtmlWebPackPlugin({
+      template: path.resolve(__dirname, '../src/index.html')
+    }),
+    new webpack.DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify(require("../package.json").version),
+      REPOSITORY_URL: JSON.stringify(require("../package.json").repository.url),
+    })
+  ],
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    plugins: [new TsconfigPathsPlugin()]
+  }
+};


### PR DESCRIPTION
I'm tackling #29 by adding a new webpack configuration called "standalone" and a related `npm run standalone` command.

The Dockerfile itself is pretty straightforward multi-stage build with `node:21` and serves them with `nginx:alpine`.


You can try out the docker process by:
```bash
docker build . -t isoflow:latest
docker run --rm -p 8081:80 isoflow
```
Then open `http://localhost:8081` on a browser.

---

Also fix a documentation error on importing `flattenCollections`.