### PR TITLE
fix: swap zoom names

### DIFF
--- a/src/components/ZoomControls/ZoomControls.tsx
+++ b/src/components/ZoomControls/ZoomControls.tsx
@@ -26,7 +26,7 @@ export const ZoomControls = () => {
       <UiElement>
         <Stack direction="row">
           <IconButton
-            name="Zoom in"
+            name="Zoom out"
             Icon={<ZoomOutIcon />}
             onClick={uiStateStoreActions.decrementZoom}
             disabled={zoom >= MAX_ZOOM}
@@ -46,7 +46,7 @@ export const ZoomControls = () => {
           </Box>
           <Divider orientation="vertical" flexItem />
           <IconButton
-            name="Zoom out"
+            name="Zoom in"
             Icon={<ZoomInIcon />}
             onClick={uiStateStoreActions.incrementZoom}
             disabled={zoom <= MIN_ZOOM}


### PR DESCRIPTION
The zoom names (`Zoom in` & `Zoom out`) were in the wrong place, should now be fixed with this commit.